### PR TITLE
Fix servo exit handling

### DIFF
--- a/test_servo.py
+++ b/test_servo.py
@@ -15,9 +15,14 @@ def set_angle(ID, angle):
 
 if __name__ == "__main__":
     boucle = True
-    while(boucle):
-        channel = int(input("channel :"))
-        angle = int(input("angle :"))
+    while boucle:
+        channel_input = input("channel :")
+        if channel_input == "exit":
+            break
+        angle_input = input("angle :")
+        if angle_input == "exit":
+            break
+
+        channel = int(channel_input)
+        angle = int(angle_input)
         set_angle(channel, angle)
-        if channel=="exit" or angle=="exit":
-            boucle = False


### PR DESCRIPTION
## Summary
- fix servo test loop to gracefully exit on user request

## Testing
- `python -m py_compile test_servo.py`

------
https://chatgpt.com/codex/tasks/task_e_684aaa7decfc832981d257e6cf0dd31d